### PR TITLE
Updates to python-aiml for Python 3.6 compatibility

### DIFF
--- a/aiml/PatternMgr.py
+++ b/aiml/PatternMgr.py
@@ -29,7 +29,7 @@ class PatternMgr:
         self._botName = u"Nameless"
         punctuation = "\"`~!@#$%^&*()-_=+[{]}\|;:',<.>/?"
         self._puncStripRE = re.compile("[" + re.escape(punctuation) + "]")
-        self._whitespaceRE = re.compile("\s+", re.LOCALE | re.UNICODE)
+        self._whitespaceRE = re.compile("\s+", re.UNICODE)
 
     def numTemplates(self):
         """Return the number of templates currently stored."""

--- a/test/test_encoding.py
+++ b/test/test_encoding.py
@@ -22,11 +22,12 @@ class TestEncoding( unittest.TestCase ):
     def tearDown(self):
         del self.k
 
-    def _testTag(self, input_, outputList, name=None):
+    def _testTag(self, input_, outputList, name=None, encoding='utf-8'):
         """Test by feeding the Kernel 'input'.  If the result
         matches any of the strings in 'outputList', the test passes.
         """
-        print( "Testing <" + (name or input_) + ">", end='\n' )
+        
+        print( b"Testing <" + (name or input_).encode(encoding) + b">")
         response = self.k._cod.dec( self.k.respond( self.k._cod.enc(input_) ) )
         self.assertIn( response, outputList, msg="input=%s"%input_ )
 
@@ -45,5 +46,7 @@ class TestEncoding( unittest.TestCase ):
         self._testTag( u'pattern with Á', [u"pattern #2 matched: Á"])
 
     def test04_iso8859( self ):
-        self.k.setTextEncoding( 'iso-8859-1' )
-        self._testTag( u'pattern with Á', [u"pattern #2 matched: Á"])
+        enc = 'iso-8859-1'
+        self.k.setTextEncoding( enc )
+        self._testTag( u'pattern with Á', [u"pattern #2 matched: Á"],
+                       encoding=enc)


### PR DESCRIPTION
Thank you for this Python 3 compatible fork of PyAIML. Unfortunately, I tried to run it on Python 3.6 and got a ValueError from aiml/PatternMgr.py. The problem was with using re.LOCALE, the usage of which was changed in Python 3.6 -- now the re pattern must be a bytes object, rather than a str object. The Python docs advise against the use of re.LOCALE so I decided to take it out. After it's removal I had no trouble using the module in Python 3.6.

I also made a change to one of the test cases. It was raising a UnicodeEncodeError when trying to print unencoded unicode characters.

I am still new to creating pull requests. Let me know if you have any concerns.