### PR TITLE
Use raw strings for regex patterns

### DIFF
--- a/aiml/Kernel.py
+++ b/aiml/Kernel.py
@@ -999,7 +999,7 @@ class Kernel:
         # space.  To improve performance, we do this only once for each
         # text element encountered, and save the results for the future.
         if elem[1]["xml:space"] == "default":
-            elem[2] = re.sub("\s+", " ", elem[2])
+            elem[2] = re.sub(r"\s+", " ", elem[2])
             elem[1]["xml:space"] = "preserve"
         return elem[2]
 

--- a/aiml/PatternMgr.py
+++ b/aiml/PatternMgr.py
@@ -27,9 +27,9 @@ class PatternMgr:
         self._root = {}
         self._templateCount = 0
         self._botName = u"Nameless"
-        punctuation = "\"`~!@#$%^&*()-_=+[{]}\|;:',<.>/?"
+        punctuation = r"""`~!@#$%^&*()-_=+[{]}\|;:'",<.>/?"""
         self._puncStripRE = re.compile("[" + re.escape(punctuation) + "]")
-        self._whitespaceRE = re.compile("\s+", re.UNICODE)
+        self._whitespaceRE = re.compile(r"\s+", re.UNICODE)
 
     def numTemplates(self):
         """Return the number of templates currently stored."""

--- a/test/__main__.py
+++ b/test/__main__.py
@@ -31,7 +31,7 @@ def script_list( path ):
     Get all the python scripts in a directory. Scripts are taken as all 
     files ending in ``.py`` that do not start with an underscore or dot.
     """
-    regexp = re.compile( '^([^_\.].+)\.py$' )
+    regexp = re.compile( r'^([^_\.].+)\.py$' )
     r = []
     for f in os.listdir(path):
         if os.path.isdir( os.path.join(path,f) ):


### PR DESCRIPTION
```
Python 3.8.0b2 (tags/v3.8.0b2:21dd01d, Jul  4 2019, 16:00:09) [MSC v.1916 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import aiml
C:\Program Files\Python38\lib\site-packages\aiml\Kernel.py:1002: SyntaxWarning: invalid escape sequence \s
  elem[2] = re.sub("\s+", " ", elem[2])
C:\Program Files\Python38\lib\site-packages\aiml\PatternMgr.py:30: SyntaxWarning: invalid escape sequence \|
  punctuation = "\"`~!@#$%^&*()-_=+[{]}\|;:',<.>/?"
C:\Program Files\Python38\lib\site-packages\aiml\PatternMgr.py:32: SyntaxWarning: invalid escape sequence \s
  self._whitespaceRE = re.compile("\s+", re.UNICODE)
```
> A backslash-character pair that is not a valid escape sequence generates a [DeprecationWarning](https://docs.python.org/3.8/library/exceptions.html#DeprecationWarning) since Python 3.6. In Python 3.8 it generates a [SyntaxWarning](https://docs.python.org/3.8/library/exceptions.html#SyntaxWarning) instead.

https://docs.python.org/3.8/whatsnew/3.8.html

> Changed in version 3.6: Unrecognized escape sequences produce a [DeprecationWarning](https://docs.python.org/3.8/library/exceptions.html#DeprecationWarning).
> 
> Changed in version 3.8: Unrecognized escape sequences produce a [SyntaxWarning](https://docs.python.org/3.8/library/exceptions.html#SyntaxWarning). In some future version of Python they will be a [SyntaxError](https://docs.python.org/3.8/library/exceptions.html#SyntaxError).

https://docs.python.org/3.8/reference/lexical_analysis.html

https://bugs.python.org/issue32912, https://github.com/python/cpython/pull/9652, https://github.com/python/cpython/commit/6543912c90ffa579dc4c01e811f9609cf92197d3
