### PR TITLE
Replace usage of time.clock() with time.time()

### DIFF
--- a/aiml/Kernel.py
+++ b/aiml/Kernel.py
@@ -129,7 +129,7 @@ class Kernel:
         processing). Upon returning the current directory is moved back to 
         where it was before.
         """
-        start = time.clock()
+        start = time.time()
         if brainFile:
             self.loadBrain(brainFile)
 
@@ -156,7 +156,7 @@ class Kernel:
                 os.chdir( prev )
 
         if self._verboseMode:
-            print( "Kernel bootstrap completed in %.2f seconds" % (time.clock() - start) )
+            print( "Kernel bootstrap completed in %.2f seconds" % (time.time() - start) )
 
     def verbose(self, isVerbose = True):
         """Enable/disable verbose output mode."""
@@ -190,19 +190,19 @@ class Kernel:
 
         """
         if self._verboseMode: print( "Loading brain from %s..." % filename, end="" )
-        start = time.clock()
+        start = time.time()
         self._brain.restore(filename)
         if self._verboseMode:
-            end = time.clock() - start
+            end = time.time() - start
             print( "done (%d categories in %.2f seconds)" % (self._brain.numTemplates(), end) )
 
     def saveBrain(self, filename):
         """Dump the contents of the bot's brain to a file on disk."""
         if self._verboseMode: print( "Saving brain to %s..." % filename, end="")
-        start = time.clock()
+        start = time.time()
         self._brain.save(filename)
         if self._verboseMode:
-            print( "done (%.2f seconds)" % (time.clock() - start) )
+            print( "done (%.2f seconds)" % (time.time() - start) )
 
     def getPredicate(self, name, sessionID = _globalSessionID):
         """Retrieve the current value of the predicate 'name' from the
@@ -326,7 +326,7 @@ class Kernel:
         """
         for f in glob.glob(filename):
             if self._verboseMode: print( "Loading %s..." % f, end="")
-            start = time.clock()
+            start = time.time()
             # Load and parse the AIML file.
             parser = create_parser()
             handler = parser.getContentHandler()
@@ -341,7 +341,7 @@ class Kernel:
                 self._brain.add(key,tem)
             # Parsing was successful.
             if self._verboseMode:
-                print( "done (%.2f seconds)" % (time.clock() - start) )
+                print( "done (%.2f seconds)" % (time.time() - start) )
 
     def respond(self, input_, sessionID = _globalSessionID):
         """Return the Kernel's response to the input string."""


### PR DESCRIPTION
`time.clock()` has been deprecated since Python 3.3:
https://docs.python.org/3.3/whatsnew/3.3.html#deprecated-python-modules-functions-and-methods
https://bugs.python.org/issue14309, https://www.python.org/dev/peps/pep-0418/#deprecated-function, https://hg.python.org/cpython/rev/314c3faea2fb, https://github.com/python/cpython/commit/47620a661128ce91f46f01fb46e1326880365e75

With Python 3.7, it now emits a `DeprecationWarning`:
https://bugs.python.org/issue31803, https://github.com/python/cpython/pull/4020, https://github.com/python/cpython/commit/884d13a55fc328e2e1e3948a82b361b30804b818
```
C:\Program Files\Python37\lib\site-packages\aiml\Kernel.py:132: DeprecationWarning: time.clock has been deprecated in Python 3.3 and will be removed from Python 3.8: use time.perf_counter or time.process_time instead
  start = time.clock()
C:\Program Files\Python37\lib\site-packages\aiml\Kernel.py:159: DeprecationWarning: time.clock has been deprecated in Python 3.3 and will be removed from Python 3.8: use time.perf_counter or time.process_time instead
  print( "Kernel bootstrap completed in %.2f seconds" % (time.clock() - start) )
C:\Program Files\Python37\lib\site-packages\aiml\Kernel.py:193: DeprecationWarning: time.clock has been deprecated in Python 3.3 and will be removed from Python 3.8: use time.perf_counter or time.process_time instead
  start = time.clock()
C:\Program Files\Python37\lib\site-packages\aiml\Kernel.py:196: DeprecationWarning: time.clock has been deprecated in Python 3.3 and will be removed from Python 3.8: use time.perf_counter or time.process_time instead
  end = time.clock() - start
C:\Program Files\Python37\lib\site-packages\aiml\Kernel.py:202: DeprecationWarning: time.clock has been deprecated in Python 3.3 and will be removed from Python 3.8: use time.perf_counter or time.process_time instead
  start = time.clock()
C:\Program Files\Python37\lib\site-packages\aiml\Kernel.py:205: DeprecationWarning: time.clock has been deprecated in Python 3.3 and will be removed from Python 3.8: use time.perf_counter or time.process_time instead
  print( "done (%.2f seconds)" % (time.clock() - start) )
C:\Program Files\Python37\lib\site-packages\aiml\Kernel.py:329: DeprecationWarning: time.clock has been deprecated in Python 3.3 and will be removed from Python 3.8: use time.perf_counter or time.process_time instead
  start = time.clock()
C:\Program Files\Python37\lib\site-packages\aiml\Kernel.py:344: DeprecationWarning: time.clock has been deprecated in Python 3.3 and will be removed from Python 3.8: use time.perf_counter or time.process_time instead
  print( "done (%.2f seconds)" % (time.clock() - start) )
```
With Python 3.8:
> The function `time.clock()` has been removed, it was deprecated since Python 3.3

https://docs.python.org/3.8/whatsnew/3.8.html#api-and-feature-removals
https://bugs.python.org/issue36895, https://github.com/python/cpython/pull/13270, https://github.com/python/cpython/commit/e2500610c62673f42371b54fb0e4de83e4b33146, https://github.com/python/cpython/pull/13286, https://github.com/python/cpython/commit/b6a09ae287e253e4146a5a224b75d4dbfd38cb63
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Program Files\Python38\lib\site-packages\aiml\Kernel.py", line 132, in bootstrap
    start = time.clock()
AttributeError: module 'time' has no attribute 'clock'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Program Files\Python38\lib\site-packages\aiml\Kernel.py", line 202, in saveBrain
    start = time.clock()
AttributeError: module 'time' has no attribute 'clock'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Program Files\Python38\lib\site-packages\aiml\Kernel.py", line 329, in learn
    start = time.clock()
AttributeError: module 'time' has no attribute 'clock'
```