### PR TITLE
Fix consecutive stars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ python_aiml.egg-info
 
 *.brn
 *.brain
+
+.ipynb_checkpoints/
+Lesson*.xml
+*.ipynb

--- a/aiml/PatternMgr.py
+++ b/aiml/PatternMgr.py
@@ -14,6 +14,7 @@ import sys
 
 from .constants import *
 
+
 class PatternMgr:
     # special dictionary keys
     _UNDERSCORE = 0
@@ -199,20 +200,21 @@ class PatternMgr:
         else:
             # unknown value
             raise ValueError( "starType must be in ['star', 'thatstar', 'topicstar']" )
-        
+
         # compare the input string to the matched pattern, word by word.
         # At the end of this loop, if foundTheRightStar is true, start and
         # end will contain the start and end indices (in "words") of
         # the substring that the desired star matched.
         foundTheRightStar = False
         start = end = j = numStars = k = 0
-        for i in range(len(words)):
+        for i in range(len(words)): # i is the word index
             # This condition is true after processing a star
             # that ISN'T the one we're looking for.
-            if i < k:
-                continue
+            if i < k: # k is the current word within the star match,
+                # or the first word after the star match.
+                continue # until the word index reaches the end of the star.
             # If we're reached the end of the pattern, we're done.
-            if j == len(patMatch):
+            if j == len(patMatch): # j is the current pattern location
                 break
             if not foundTheRightStar:
                 if patMatch[j] in [self._STAR, self._UNDERSCORE]: #we got a star
@@ -221,19 +223,25 @@ class PatternMgr:
                         # This is the star we care about.
                         foundTheRightStar = True
                     start = i
-                    # Iterate through the rest of the string.
-                    for k in range (i, len(words)):
-                        # If the star is at the end of the pattern,
-                        # we know exactly where it ends.
-                        if j+1  == len (patMatch):
-                            end = len (words)
-                            break
-                        # If the words have started matching the
-                        # pattern again, the star has ended.
-                        if patMatch[j+1] == words[k]:
-                            end = k - 1
-                            i = k
-                            break
+                    # If the star is at the end of the pattern,
+                    # match the rest of the words.
+                    if j+1 == len (patMatch):
+                        end = len (words)
+                    else:
+                        # If the next word in the pattern is another star, then
+                        # we only want to match the one word
+                        if patMatch[j+1] in [self._STAR, self._UNDERSCORE]:
+                            end = j
+                        else:
+                            # Iterate through the rest of the words searching
+                            # for the end of the star.
+                            for k in range (i, len(words)):
+                                # If the words have started matching the
+                                # pattern again, the star has ended.
+                                if patMatch[j+1] == words[k]:
+                                    end = k - 1
+                                    i = k
+                                    break
                 # If we just finished processing the star we cared
                 # about, we exit the loop early.
                 if foundTheRightStar:
@@ -243,10 +251,13 @@ class PatternMgr:
             
         # extract the star words from the original, unmutilated input.
         if foundTheRightStar:
-            #print( ' '.join(pattern.split()[start:end+1]) )
-            if starType == 'star': return ' '.join(pattern.split()[start:end+1])
-            elif starType == 'thatstar': return ' '.join(that.split()[start:end+1])
-            elif starType == 'topicstar': return ' '.join(topic.split()[start:end+1])
+            if starType == 'star':
+                match = ' '.join(pattern.split()[start:end+1])
+            elif starType == 'thatstar':
+                match = ' '.join(that.split()[start:end+1])
+            elif starType == 'topicstar':
+                match = ' '.join(topic.split()[start:end+1])
+            return match
         else: return u""
 
     def _match(self, words, thatWords, topicWords, root):


### PR DESCRIPTION
I had a problem with a <that> with two consecutive stars in it, one for a person's first name and the second for the last name. The <thatstar index="2"/> was returning the last name correctly, but the `<thatstar/>` or `<thatstar index="1"/>` kept coming back empty. It turned out to be that the parser was looking for a match between the next word in the pattern and the next word in the words list. When the next word was a star, it would not match.

Here is an example:
``` xml
<aiml>
    <category>
        <pattern>ASK ME A QUESTION</pattern>
        <template>
            <random>
                <li>Do you listen to <random>
                    <li>Elvis Presley</li>
                    <li>Eddie Van Halen</li>
                    <li>Michael Jackson</li>
                </random> music?</li>
            </random>
        </template>
    </category>
    <category>
        <pattern>YES</pattern>
        <that>DO YOU LISTEN TO * * MUSIC</that>
        <template>I also listen to Mr. <thatstar index="2"/></template>
    </category>
    <category>
        <pattern>NO</pattern>
        <that>DO YOU LISTEN TO * * MUSIC</that>
        <template>Well <thatstar/> listens to you!</template>
    </category>
</aiml>
```
This fixes the issue by checking if the next word in a match is another star and, if so, then stopping after the first word.

I also took the liberty of adding Jupyter Notebook files to .gitignore so I wouldn't see mine when getting git status.